### PR TITLE
Refine card and task interactions

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1551,8 +1551,8 @@ test("assigning tasks uses direct task claims and keeps played cards in the crew
   );
 
   await expect(
-    adaStation.getByRole("img", { name: "Pink 1", exact: true }),
-  ).toBeVisible();
+    adaStation.getByRole("button", { name: "Pink 1", exact: true }),
+  ).toBeDisabled();
   await expect(
     adaStation.getByRole("group", { name: "Resolve Win the Pink 1" }),
   ).toBeVisible();
@@ -1582,18 +1582,18 @@ test("assigning tasks uses direct task claims and keeps played cards in the crew
   await expect(
     page
       .getByRole("article", { name: "Ada station" })
-      .getByRole("img", { name: "Pink 1", exact: true }),
-  ).toBeVisible();
+      .getByRole("button", { name: "Pink 1", exact: true }),
+  ).toBeDisabled();
   await expect(
     page
       .getByRole("article", { name: "Grace station" })
-      .getByRole("img", { name: "Blue 2", exact: true }),
-  ).toBeVisible();
+      .getByRole("button", { name: "Blue 2", exact: true }),
+  ).toBeDisabled();
   await expect(
     page
       .getByRole("article", { name: "Katherine station" })
-      .getByRole("img", { name: "Green 3", exact: true }),
-  ).toBeVisible();
+      .getByRole("button", { name: "Green 3", exact: true }),
+  ).toBeDisabled();
   await expect(
     page.getByRole("heading", { name: "Current trick" }),
   ).toHaveCount(0);

--- a/e2e/assets.spec.ts
+++ b/e2e/assets.spec.ts
@@ -33,7 +33,7 @@ test("assets exposes every canonical card and goal", async ({ page }) => {
   );
   await expect(
     page.getByRole("button", { name: /View details for/ }),
-  ).toHaveCount(DEEP_SEA_TASKS.length);
+  ).toHaveCount(0);
   await expect(
     page.locator('[data-slot="deep-sea-task-difficulty"]'),
   ).toHaveCount(0);
@@ -46,6 +46,15 @@ test("assets exposes every canonical card and goal", async ({ page }) => {
       '[data-asset-mode="deep-sea"] [aria-label^="Difficulty:"]',
     ),
   ).toHaveCount(0);
+  const deepSeaAssets = page.locator('[data-asset-mode="deep-sea"]');
+  await expect(
+    deepSeaAssets.getByText("WIN =0×", { exact: true }),
+  ).toHaveCount(9);
+  await expect(deepSeaAssets.getByText("0×", { exact: true })).toHaveCount(2);
+  await expect(
+    deepSeaAssets.getByText("Win 0× tricks", { exact: true }),
+  ).toHaveCount(1);
+  await expect(deepSeaAssets.getByText(/0(?:x|ˣ)/)).toHaveCount(0);
 
   const task88 = page.locator('[data-asset-task="deep-sea-task-88"]');
   const task88Spacing = await task88.evaluate((element) => {
@@ -130,20 +139,44 @@ test("assets exposes every canonical card and goal", async ({ page }) => {
   await expect(page.getByText("36 goals", { exact: true })).toBeVisible();
 });
 
+test("cards are interactive unless disabled without a disabled appearance", async ({
+  page,
+}) => {
+  await page.goto("/assets");
+
+  await expect(
+    page.getByRole("combobox", { name: "Selection", exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("combobox", { name: "Element", exact: true }),
+  ).toHaveCount(0);
+  const firstCard = page.locator("[data-asset-card]").first();
+  await expect(page.locator("[data-asset-card]")).toHaveCount(CARD_DECK.length);
+  await expect(firstCard.getByRole("button")).toBeEnabled();
+  await expect(firstCard).not.toHaveAttribute("data-asset-interactive", /.+/);
+  await expect(firstCard).not.toHaveAttribute("data-asset-selected", /.+/);
+
+  await choose(page, "Availability", "Disabled");
+  await expect(firstCard).toHaveAttribute("data-asset-disabled", "true");
+  await expect(firstCard.getByRole("button")).toBeDisabled();
+  await expect(firstCard.getByRole("button")).toHaveCSS("filter", "none");
+  await expect(firstCard.getByRole("button")).toHaveCSS("opacity", "1");
+  await expect(firstCard.getByRole("button")).not.toHaveAttribute(
+    "aria-pressed",
+    /.+/,
+  );
+});
+
 test("asset controls reach every meaningful card and goal state", async ({
   page,
 }) => {
   await page.goto("/assets");
 
-  await choose(page, "Element", "Interactive");
-  await choose(page, "Selection", "Selected");
   await choose(page, "Availability", "Disabled");
   await choose(page, "Scale", "Communication · 80%");
 
   const firstCard = page.locator("[data-asset-card]").first();
   await expect(page.locator("[data-asset-card]")).toHaveCount(CARD_DECK.length);
-  await expect(firstCard).toHaveAttribute("data-asset-interactive", "true");
-  await expect(firstCard).toHaveAttribute("data-asset-selected", "true");
   await expect(firstCard).toHaveAttribute("data-asset-disabled", "true");
   await expect(firstCard).toHaveAttribute(
     "data-asset-scale",
@@ -184,26 +217,27 @@ test("asset controls reach every meaningful card and goal state", async ({
     .toHaveAttribute("data-task-outcome", "success");
   const deepSeaBoot = firstDeepSeaGoal.locator('[data-slot="task-boot"]');
   await expect(deepSeaBoot).toBeVisible();
-  await expect(deepSeaBoot).toHaveCSS(
-    "background-color",
-    "oklch(0.929 0.013 255.508)",
-  );
+  await expect(deepSeaBoot).toHaveClass(/bg-slate-200/);
   const deepSeaStatus = deepSeaBoot.locator('[data-slot="task-status"]');
   await expect(deepSeaStatus).toBeVisible();
-  await expect(deepSeaStatus).toHaveCSS(
-    "background-color",
-    "rgb(255, 255, 255)",
-  );
+  await expect(deepSeaStatus).toHaveClass(/bg-green-500/);
+  await expect(deepSeaStatus).toHaveCSS("border-width", "0px");
+  await expect(deepSeaStatus).toHaveCSS("height", "14px");
+  await expect(deepSeaStatus).toHaveCSS("width", "14px");
   await expect(deepSeaStatus.locator("svg")).toHaveCSS(
     "color",
-    "oklch(0.723 0.219 149.579)",
+    "rgb(255, 255, 255)",
   );
   const difficultyBadge = deepSeaBoot.locator(
     '[data-slot="deep-sea-task-difficulty"]',
   );
   await expect(difficultyBadge).toBeVisible();
   await expect(difficultyBadge).toHaveCSS("height", "14px");
-  await expect(difficultyBadge).toHaveCSS("width", "14px");
+  const difficultyWidth = await difficultyBadge.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  expect(difficultyWidth).toBeGreaterThan(14);
+  expect(difficultyWidth).toBeLessThan(28);
   await expect(difficultyBadge).toHaveCSS(
     "background-color",
     "rgb(255, 255, 255)",
@@ -212,26 +246,57 @@ test("asset controls reach every meaningful card and goal state", async ({
   await expect(firstDeepSeaGoal.getByRole("img")).toHaveAccessibleName(
     /Unassigned\. Successful\. Difficulty \d+\./,
   );
-  const infoButton = deepSeaBoot.getByRole("button", {
+  const difficultyButton = deepSeaBoot.getByRole("button", {
     name: /View details for/,
   });
-  await expect(infoButton).toBeVisible();
-  await expect(infoButton).toHaveCSS("height", "14px");
-  await expect(infoButton).toHaveCSS("width", "14px");
-  await expect(infoButton).toHaveCSS(
+  await expect(difficultyButton).toBeVisible();
+  const difficultyFontSize = await difficultyButton.evaluate(
+    (element) => getComputedStyle(element).fontSize,
+  );
+  await expect(difficultyButton).toHaveAttribute(
+    "data-slot",
+    "deep-sea-task-difficulty",
+  );
+  expect(
+    await deepSeaBoot.evaluate((element) =>
+      Array.from(element.children, (child) => child.getAttribute("data-slot")),
+    ),
+  ).toEqual(["deep-sea-task-difficulty", "task-status"]);
+  expect(
+    await deepSeaBoot
+      .locator(":scope > [data-slot]")
+      .evaluateAll((elements) =>
+        elements.map((element) => element.getBoundingClientRect().height),
+      ),
+  ).toEqual([14, 14]);
+  await expect(difficultyButton).toHaveCSS("height", "14px");
+  expect(
+    await difficultyButton.evaluate(
+      (element) => element.getBoundingClientRect().width,
+    ),
+  ).toBe(difficultyWidth);
+  await expect(difficultyButton).toHaveCSS(
     "background-color",
     "rgb(255, 255, 255)",
   );
-  await infoButton.hover();
-  await expect(infoButton).toHaveCSS(
+  const difficultyNumber = difficultyButton.locator("span");
+  const difficultyIcon = difficultyButton.locator("svg");
+  await expect(difficultyNumber).toHaveCSS("color", "rgb(40, 35, 93)");
+  const restingIconColor = await difficultyIcon.evaluate(
+    (element) => getComputedStyle(element).color,
+  );
+  await difficultyButton.hover();
+  await expect(difficultyButton).toHaveCSS(
     "background-color",
-    "oklch(0.968 0.007 247.896)",
+    "rgb(255, 255, 255)",
   );
-  await expect(infoButton).toHaveCSS(
-    "color",
-    "oklch(0.457 0.24 277.023)",
+  await expect(difficultyIcon).toHaveClass(
+    /group-hover:text-slate-600/,
   );
-  await infoButton.click();
+  expect(await difficultyIcon.evaluate((element) => getComputedStyle(element).color))
+    .not.toBe(restingIconColor);
+  await expect(difficultyNumber).toHaveCSS("color", "rgb(40, 35, 93)");
+  await difficultyButton.click();
   await expect(page.getByRole("dialog")).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Task 1" }),
@@ -242,6 +307,29 @@ test("asset controls reach every meaningful card and goal state", async ({
       .getByText("I will win a trick using a 5", { exact: true }),
   ).toBeVisible();
   await page.keyboard.press("Escape");
+
+  await choose(page, "Outcome", "Pending");
+  await expect(firstDeepSeaGoal.locator("[data-task-outcome]"))
+    .toHaveAttribute("data-task-outcome", "pending");
+  await expect(deepSeaStatus).toHaveCSS(
+    "background-color",
+    "rgb(255, 255, 255)",
+  );
+  await expect(deepSeaStatus.locator("svg")).toHaveCSS(
+    "color",
+    "rgb(0, 0, 0)",
+  );
+
+  await choose(page, "Outcome", "Failed");
+  await expect(firstDeepSeaGoal.locator("[data-task-outcome]"))
+    .toHaveAttribute("data-task-outcome", "failure");
+  await expect(deepSeaStatus).toHaveClass(/bg-red-600/);
+  await expect(deepSeaStatus.locator("svg")).toHaveCSS(
+    "color",
+    "rgb(255, 255, 255)",
+  );
+
+  await choose(page, "Outcome", "Successful");
 
   await choose(page, "Asset mode", "Planet X");
   await expect(
@@ -273,8 +361,28 @@ test("asset controls reach every meaningful card and goal state", async ({
     .toHaveAttribute("data-task-outcome", "success");
   const planetXBoot = firstPlanetXGoal.locator('[data-slot="task-boot"]');
   await expect(planetXBoot).toBeVisible();
-  await expect(planetXBoot.locator('[data-slot="task-status"]')).toBeVisible();
-  await expect(planetXBoot.locator('[data-slot="task-order"]')).toBeVisible();
+  const planetXStatus = planetXBoot.locator('[data-slot="task-status"]');
+  await expect(planetXStatus).toBeVisible();
+  const planetXOrder = planetXBoot.locator('[data-slot="task-order"]');
+  await expect(planetXOrder).toBeVisible();
+  await expect(planetXOrder).toHaveCSS("border-width", "0px");
+  expect(
+    await planetXOrder.evaluate(
+      (element) => getComputedStyle(element).fontSize,
+    ),
+  ).toBe(difficultyFontSize);
+  expect(
+    await planetXBoot.evaluate((element) =>
+      Array.from(element.children, (child) => child.getAttribute("data-slot")),
+    ),
+  ).toEqual(["task-order", "task-status"]);
+  expect(
+    await planetXBoot
+      .locator(":scope > [data-slot]")
+      .evaluateAll((elements) =>
+        elements.map((element) => element.getBoundingClientRect().height),
+      ),
+  ).toEqual([14, 14]);
   await expect(
     planetXBoot.locator('[data-slot="deep-sea-task-difficulty"]'),
   ).toHaveCount(0);

--- a/e2e/cards.spec.ts
+++ b/e2e/cards.spec.ts
@@ -317,8 +317,12 @@ test("Planet X task cards use the outlined mini Crew pill", async ({
     const pill = element
       .querySelector<HTMLElement>('[data-slot="task-card"]')!
       .getBoundingClientRect();
+    const boot = element
+      .querySelector<HTMLElement>('[data-slot="task-boot"]')!
+      .getBoundingClientRect();
 
     return {
+      bootTopDelta: boot.top - face.bottom,
       faceHeight: face.height,
       faceWidth: face.width,
       pillHeight: pill.height,
@@ -328,12 +332,36 @@ test("Planet X task cards use the outlined mini Crew pill", async ({
     };
   });
 
+  expect(emphasizedGeometry.bootTopDelta).toBeCloseTo(0, 1);
   expect(emphasizedGeometry.faceHeight).toBeCloseTo(84, 1);
   expect(emphasizedGeometry.faceWidth).toBeCloseTo(84, 1);
   expect(emphasizedGeometry.pillHeight).toBeCloseTo(33.6, 1);
   expect(emphasizedGeometry.pillWidth).toBeCloseTo(57.6, 1);
   expect(emphasizedGeometry.xCenterDelta).toBeCloseTo(0, 1);
   expect(emphasizedGeometry.yCenterDelta).toBeCloseTo(0, 1);
+  const bootFrame = emphasizedTask.locator('[data-slot="task-boot-frame"]');
+  await expect(bootFrame).toHaveClass(/before:bg-slate-200/);
+  const bootExtension = await bootFrame.evaluate((element) => {
+      const style = getComputedStyle(element, "::before");
+      const boot = element.querySelector<HTMLElement>('[data-slot="task-boot"]')!;
+      return {
+        backgroundColor: style.backgroundColor,
+        bootBackgroundColor: getComputedStyle(boot).backgroundColor,
+        height: style.height,
+        top: style.top,
+        zIndex: style.zIndex,
+      };
+    });
+  expect(bootExtension.backgroundColor).toBe(
+    bootExtension.bootBackgroundColor,
+  );
+  expect(bootExtension).toEqual({
+    backgroundColor: bootExtension.bootBackgroundColor,
+    bootBackgroundColor: bootExtension.bootBackgroundColor,
+    height: "4px",
+    top: "-4px",
+    zIndex: "0",
+  });
 
   await page.getByRole("combobox", { name: "Size", exact: true }).click();
   await page.getByRole("option", { name: "Default · 56px" }).click();
@@ -380,14 +408,19 @@ test("Planet X task cards use the outlined mini Crew pill", async ({
       const pill = element
         .querySelector<HTMLElement>('[data-slot="task-card"]')!
         .getBoundingClientRect();
+      const bootRect = element
+        .querySelector<HTMLElement>('[data-slot="task-boot"]')!
+        .getBoundingClientRect();
 
       return {
+        bootTopDelta: bootRect.top - face.bottom,
         pillHeight: pill.height,
         pillWidth: pill.width,
         xCenterDelta: (pill.left + pill.right - face.left - face.right) / 2,
         yCenterDelta: (pill.top + pill.bottom - face.top - face.bottom) / 2,
       };
     });
+    expect(defaultGeometry.bootTopDelta).toBeCloseTo(0, 1);
     expect(defaultGeometry.pillHeight).toBeCloseTo(26.4, 1);
     expect(defaultGeometry.pillWidth).toBeCloseTo(44.8, 1);
     expect(defaultGeometry.xCenterDelta).toBeCloseTo(0, 1);

--- a/e2e/drag-interactions.spec.ts
+++ b/e2e/drag-interactions.spec.ts
@@ -1,5 +1,11 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test, type Page, type Route } from "@playwright/test";
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type Route,
+} from "@playwright/test";
 
 import type { ActorProjection, Card } from "../src/components/game/types";
 
@@ -96,6 +102,47 @@ function makeProjection(): ActorProjection {
   };
 }
 
+function makeTaskAssignmentProjection(): ActorProjection {
+  const projection = makeProjection();
+
+  return {
+    ...projection,
+    mission: {
+      ...projection.mission,
+      editionKey: "deep-sea",
+      missionKey: "deep-sea:1",
+      title: "First Dive",
+      manualRule: false,
+    },
+    phase: "assigning-tasks",
+    players: projection.players.map((player) => ({
+      ...player,
+      isCurrent: false,
+    })),
+    tasks: [
+      {
+        id: "task-1",
+        definitionId: "deep-sea-task-85",
+        difficulty: 3,
+        cardId: null,
+        order: null,
+        ownerPlayerId: null,
+        ownerDisplayName: null,
+        outcome: "pending",
+        title: "I will win exactly two 9s",
+        footnote: null,
+      },
+    ],
+    legalActions: {
+      ...projection.legalActions,
+      canStartTrick: false,
+      claimableTaskIds: ["task-1"],
+      playableCardIds: [],
+      communicationOptions: [],
+    },
+  };
+}
+
 type Projection = ActorProjection;
 
 async function fulfillJson(route: Route, body: unknown) {
@@ -109,8 +156,9 @@ async function fulfillJson(route: Route, body: unknown) {
 async function openMockedRoom(
   page: Page,
   onAction: (command: Record<string, unknown>, projection: Projection) => Projection,
+  initialProjection: Projection = makeProjection(),
 ) {
-  let projection = makeProjection();
+  let projection = initialProjection;
   const actions: Array<Record<string, unknown>> = [];
 
   await page.addInitScript(
@@ -171,6 +219,45 @@ async function dragCard(page: Page, cardId: string, targetSelector: string) {
     .dragTo(page.locator(targetSelector), { steps: 12 });
 }
 
+async function dragTaskFace(
+  page: Page,
+  taskButton: Locator,
+  target: Locator,
+  ownStation: Locator,
+  allowed: boolean,
+) {
+  const source = taskButton.locator('[data-slot="task-face"]');
+  const [sourceBox, targetBox] = await Promise.all([
+    source.boundingBox(),
+    target.boundingBox(),
+  ]);
+  expect(sourceBox).not.toBeNull();
+  expect(targetBox).not.toBeNull();
+
+  const sourcePoint = {
+    x: sourceBox!.x + sourceBox!.width / 2,
+    y: sourceBox!.y + sourceBox!.height / 2,
+  };
+  const targetPoint = {
+    x: targetBox!.x + targetBox!.width / 2,
+    y: targetBox!.y + targetBox!.height / 2,
+  };
+
+  await page.mouse.move(sourcePoint.x, sourcePoint.y);
+  await page.mouse.down();
+  await page.mouse.move(sourcePoint.x + 12, sourcePoint.y, { steps: 2 });
+  await expect(ownStation).toHaveAttribute(
+    "data-task-drop-state",
+    "available",
+  );
+  await page.mouse.move(targetPoint.x, targetPoint.y, { steps: 12 });
+  await expect(ownStation).toHaveAttribute(
+    "data-task-drop-state",
+    allowed ? "active" : "available",
+  );
+  await page.mouse.up();
+}
+
 async function expectNoAccessibilityViolations(page: Page) {
   const results = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
@@ -178,6 +265,176 @@ async function expectNoAccessibilityViolations(page: Page) {
 
   expect(results.violations).toEqual([]);
 }
+
+test("a task face only assigns when dropped on the current player's Crew station", async ({
+  page,
+}) => {
+  const initialProjection = makeTaskAssignmentProjection();
+  const { actions } = await openMockedRoom(
+    page,
+    (command, projection) => {
+      if (command.type !== "claim-task") return projection;
+
+      return {
+        ...projection,
+        phase: "ready-to-start-trick",
+        tasks: projection.tasks.map((task) =>
+          task.id === command.taskId
+            ? {
+                ...task,
+                ownerPlayerId: projection.self.id,
+                ownerDisplayName: projection.self.displayName,
+              }
+            : task,
+        ),
+        legalActions: {
+          ...projection.legalActions,
+          canStartTrick: true,
+          claimableTaskIds: [],
+          releasableTaskIds: [command.taskId as string],
+        },
+      };
+    },
+    initialProjection,
+  );
+  const taskButton = page.getByRole("button", {
+    name: "Assign I will win exactly two 9s to me",
+  });
+  const ownStation = page.locator('[data-task-drop-target="claim"]');
+  const otherStation = page.getByRole("article", {
+    name: "Grace station",
+  });
+
+  await expect(taskButton.locator('[data-slot="task-face"]')).toBeVisible();
+  await expect(taskButton.locator('[data-slot="task-boot"]')).toHaveCount(0);
+  await dragTaskFace(page, taskButton, otherStation, ownStation, false);
+  await expect(taskButton).toHaveAttribute("data-task-dragging", "false");
+  await expect(ownStation).toHaveAttribute("data-task-drop-state", "idle");
+  expect(actions).toEqual([]);
+
+  await dragTaskFace(page, taskButton, ownStation, ownStation, true);
+
+  await expect.poll(() => actions).toEqual([
+    { type: "claim-task", taskId: "task-1" },
+  ]);
+  await expect(
+    page
+      .getByRole("region", { name: "Mission board" })
+      .getByRole("button", {
+        name: "Deselect I will win exactly two 9s",
+      }),
+  ).toBeVisible();
+});
+
+test("task assignment keeps click and keyboard fallbacks", async ({ page }) => {
+  const { actions } = await openMockedRoom(
+    page,
+    (_command, projection) => projection,
+    makeTaskAssignmentProjection(),
+  );
+  const taskButton = page.getByRole("button", {
+    name: "Assign I will win exactly two 9s to me",
+  });
+
+  await taskButton.locator('[data-slot="task-face"]').click();
+  await expect.poll(() => actions).toEqual([
+    { type: "claim-task", taskId: "task-1" },
+  ]);
+  await expect(taskButton).toBeEnabled();
+
+  actions.length = 0;
+  await taskButton.focus();
+  await page.keyboard.press("Enter");
+  await expect.poll(() => actions).toEqual([
+    { type: "claim-task", taskId: "task-1" },
+  ]);
+  await expect(taskButton).toBeEnabled();
+
+  actions.length = 0;
+  await taskButton.focus();
+  await page.keyboard.press("Space");
+  await expect.poll(() => actions).toEqual([
+    { type: "claim-task", taskId: "task-1" },
+  ]);
+});
+
+test("a long-press touch drag assigns a task on a touch screen", async ({
+  browser,
+}, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== "string") {
+    throw new Error("The Playwright project must define a base URL.");
+  }
+
+  const context = await browser.newContext({
+    baseURL,
+    hasTouch: true,
+    isMobile: true,
+    viewport: { width: 1024, height: 640 },
+  });
+  const page = await context.newPage();
+
+  try {
+    const { actions } = await openMockedRoom(
+      page,
+      (_command, projection) => projection,
+      makeTaskAssignmentProjection(),
+    );
+    const source = page
+      .getByRole("button", {
+        name: "Assign I will win exactly two 9s to me",
+      })
+      .locator('[data-slot="task-face"]');
+    const target = page.locator('[data-task-drop-target="claim"]');
+    const [sourceBox, targetBox] = await Promise.all([
+      source.boundingBox(),
+      target.boundingBox(),
+    ]);
+    expect(sourceBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    const sourcePoint = {
+      x: sourceBox!.x + sourceBox!.width / 2,
+      y: sourceBox!.y + sourceBox!.height / 2,
+    };
+    const targetPoint = {
+      x: targetBox!.x + targetBox!.width / 2,
+      y: targetBox!.y + targetBox!.height / 2,
+    };
+    const client = await context.newCDPSession(page);
+
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [sourcePoint],
+    });
+    await page.waitForTimeout(220);
+    await expect(target).toHaveAttribute("data-task-drop-state", "available");
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [
+        {
+          x: (sourcePoint.x + targetPoint.x) / 2,
+          y: (sourcePoint.y + targetPoint.y) / 2,
+        },
+      ],
+    });
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [targetPoint],
+    });
+    await expect(target).toHaveAttribute("data-task-drop-state", "active");
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+
+    await expect.poll(() => actions).toEqual([
+      { type: "claim-task", taskId: "task-1" },
+    ]);
+  } finally {
+    await context.close();
+  }
+});
 
 test("dragging a legal card to the played station plays it", async ({
   page,
@@ -250,8 +507,8 @@ test("dragging a legal card to the played station plays it", async ({
   await expect(
     page
       .getByRole("article", { name: "Ada station" })
-      .getByRole("img", { name: "Pink 1", exact: true }),
-  ).toBeVisible();
+      .getByRole("button", { name: "Pink 1", exact: true }),
+  ).toBeDisabled();
   await expect(page.getByRole("region", { name: "Crew" })).toHaveAttribute(
     "data-crew-layout",
     "main",

--- a/src/components/game/AssetsGallery.tsx
+++ b/src/components/game/AssetsGallery.tsx
@@ -28,8 +28,6 @@ import { TaskTile } from "./TaskTile";
 
 type AssetMode = "cards" | "deep-sea" | "planet-nine";
 type CardConfiguration = {
-  interactive: boolean;
-  selected: boolean;
   disabled: boolean;
   scale: "full" | "communication";
 };
@@ -101,16 +99,6 @@ const modeDetails = {
   },
 } satisfies Record<AssetMode, { label: string; summary: string }>;
 
-const cardInteractionOptions = [
-  { label: "Static", value: "static" },
-  { label: "Interactive", value: "interactive" },
-] as const satisfies readonly ControlOption[];
-
-const cardSelectionOptions = [
-  { label: "Not selected", value: "false" },
-  { label: "Selected", value: "true" },
-] as const satisfies readonly ControlOption[];
-
 const cardAvailabilityOptions = [
   { label: "Available", value: "false" },
   { label: "Disabled", value: "true" },
@@ -156,8 +144,6 @@ export function AssetsGallery() {
   const [mode, setMode] = useState<AssetMode>("cards");
   const [cardConfiguration, setCardConfiguration] =
     useState<CardConfiguration>({
-      interactive: false,
-      selected: false,
       disabled: false,
       scale: "full",
     });
@@ -245,15 +231,7 @@ export function AssetsGallery() {
             </div>
 
             {mode === "cards" ? (
-              <PlayingCards
-                configuration={cardConfiguration}
-                onToggleSelected={() =>
-                  setCardConfiguration((current) => ({
-                    ...current,
-                    selected: !current.selected,
-                  }))
-                }
-              />
+              <PlayingCards configuration={cardConfiguration} />
             ) : null}
             {mode === "deep-sea" ? (
               <DeepSeaGoals
@@ -281,25 +259,9 @@ function CardControls({
 }) {
   return (
     <PreviewControls
-      description="These settings apply to all 40 cards without changing the deck. Disabled only affects the interactive form."
+      description="These settings apply to all 40 cards without changing the deck. Disabled prevents interaction without changing the card appearance."
       title="Card state"
     >
-      <ControlSelect
-        label="Element"
-        name="card-interaction"
-        options={cardInteractionOptions}
-        value={configuration.interactive ? "interactive" : "static"}
-        onValueChange={(value) =>
-          onChange({ interactive: value === "interactive" })
-        }
-      />
-      <ControlSelect
-        label="Selection"
-        name="card-selection"
-        options={cardSelectionOptions}
-        value={String(configuration.selected)}
-        onValueChange={(value) => onChange({ selected: value === "true" })}
-      />
       <ControlSelect
         label="Availability"
         name="card-availability"
@@ -461,10 +423,8 @@ function ControlSelect({
 
 function PlayingCards({
   configuration,
-  onToggleSelected,
 }: {
   configuration: CardConfiguration;
-  onToggleSelected: () => void;
 }) {
   return (
     <div
@@ -492,29 +452,18 @@ function PlayingCards({
                 className="flex justify-center"
                 data-asset-card={card.id}
                 data-asset-disabled={configuration.disabled}
-                data-asset-interactive={configuration.interactive}
                 data-asset-scale={configuration.scale}
-                data-asset-selected={configuration.selected}
               >
                 <GameCard
                   card={card}
                   disabled={configuration.disabled}
                   labelPrefix={
-                    configuration.interactive
-                      ? configuration.disabled
-                        ? "Unavailable"
-                        : configuration.selected
-                          ? "Deselect preview"
-                          : "Select preview"
-                      : undefined
+                    configuration.disabled ? "Unavailable" : "Preview"
                   }
-                  selected={configuration.selected}
                   transformScale={
                     configuration.scale === "communication" ? 0.8 : undefined
                   }
-                  onClick={
-                    configuration.interactive ? onToggleSelected : undefined
-                  }
+                  onClick={() => undefined}
                 />
               </div>
             ))}

--- a/src/components/game/GameCard.tsx
+++ b/src/components/game/GameCard.tsx
@@ -11,7 +11,6 @@ import type { Card } from "./types";
 type GameCardProps = {
   card: Card;
   disabled?: boolean;
-  selected?: boolean;
   /** Visual-only CSS transform scale; the fixed card layout box is unchanged. */
   transformScale?: number;
   onClick?: () => void;
@@ -22,7 +21,6 @@ type GameCardProps = {
 export function GameCard({
   card,
   disabled = false,
-  selected = false,
   transformScale,
   onClick,
   labelPrefix,
@@ -30,13 +28,10 @@ export function GameCard({
 }: GameCardProps) {
   const { Icon, label: suitLabel } =
     CARD_SUIT_META[card.suit] ?? CARD_SUIT_META.blue;
+  const isDisabled = disabled || onClick === undefined;
   const className = cn(
-    "game-card relative block h-28 w-20 flex-none overflow-hidden rounded-xl border-0 bg-white p-1.5 select-none",
+    "game-card relative block h-28 min-h-0 w-20 flex-none cursor-pointer appearance-none overflow-hidden rounded-xl border-0 bg-white p-1.5 transition-[translate,outline-color] duration-120 select-none enabled:hover:z-2 enabled:hover:translate-y-[-0.2rem] focus-visible:outline-[3px] focus-visible:outline-solid focus-visible:outline-card-focus focus-visible:outline-offset-[3px] motion-reduce:transition-none motion-reduce:enabled:hover:translate-y-0",
     CARD_SUIT_COLOR_CLASS_NAME[card.suit],
-    onClick &&
-      "min-h-0 cursor-pointer appearance-none transition-[translate,outline-color] duration-120 enabled:hover:z-2 enabled:hover:translate-y-[-0.2rem] focus-visible:outline-[3px] focus-visible:outline-solid focus-visible:outline-card-focus focus-visible:outline-offset-[3px] disabled:cursor-not-allowed disabled:filter-[grayscale(0.55)] disabled:opacity-[0.48] disabled:translate-y-0 motion-reduce:transition-none motion-reduce:enabled:hover:translate-y-0",
-    selected &&
-      "game-card--selected translate-y-[-0.2rem] outline-[3px] outline-solid outline-card-focus outline-offset-2 motion-reduce:translate-y-0",
     // Stable hooks allow the room layout to size cards without owning their visual treatment.
     `game-card--${card.suit}`,
   );
@@ -74,35 +69,19 @@ export function GameCard({
     </>
   );
 
-  if (onClick) {
-    return (
-      <button
-        ref={buttonRef}
-        className={className}
-        style={style}
-        data-card-suit={card.suit}
-        data-slot="game-card"
-        type="button"
-        disabled={disabled}
-        aria-pressed={selected || undefined}
-        aria-label={label}
-        onClick={onClick}
-      >
-        {contents}
-      </button>
-    );
-  }
-
   return (
-    <span
+    <button
+      ref={buttonRef}
       className={className}
       style={style}
       data-card-suit={card.suit}
       data-slot="game-card"
-      role="img"
+      type="button"
+      disabled={isDisabled}
       aria-label={label}
+      onClick={onClick}
     >
       {contents}
-    </span>
+    </button>
   );
 }

--- a/src/components/game/RoomShell.test.tsx
+++ b/src/components/game/RoomShell.test.tsx
@@ -110,7 +110,7 @@ describe("RoomShellImpl", () => {
       />,
     );
     const infoLabel =
-      'aria-label="View details for I will win exactly two 9s"';
+      'aria-label="Difficulty 3. View details for I will win exactly two 9s"';
 
     function expectSiblingBoot(markup: string, selectionLabel: string) {
       const labelIndex = markup.indexOf(`aria-label="${selectionLabel}"`);
@@ -121,6 +121,7 @@ describe("RoomShellImpl", () => {
 
       expect(labelIndex).toBeGreaterThan(-1);
       expect(selectionButton.match(/<button/g)).toHaveLength(1);
+      expect(selectionButton).toContain(`data-task-id="${deepSeaTask.id}"`);
       expect(selectionButton).not.toContain(infoLabel);
       expect(selectionButton).not.toContain('data-slot="task-boot"');
       expect(bootIndex).toBeGreaterThan(buttonEnd);
@@ -167,12 +168,12 @@ describe("RoomShellImpl", () => {
 
     expectSiblingBoot(readyMarkup, "Deselect I will win exactly two 9s");
     expect(readyMarkup).toContain(
-      'aria-label="View details for I will win a trick using a 5"',
+      'aria-label="Difficulty 2. View details for I will win a trick using a 5"',
     );
   });
 
-  it("keeps the active Deep Sea boot without its pregame info trigger", () => {
-    const projection = deepSeaProjection("between-tricks");
+  it("opens Deep Sea details from difficulty during an active trick", () => {
+    const projection = deepSeaProjection("playing-trick");
     projection.tasks = [
       {
         ...deepSeaTask,
@@ -195,6 +196,9 @@ describe("RoomShellImpl", () => {
     expect(markup).toContain('data-slot="task-boot"');
     expect(markup).toContain('data-slot="task-status"');
     expect(markup).toContain('data-slot="deep-sea-task-difficulty"');
-    expect(markup).not.toContain("View details for");
+    expect(markup).toContain(
+      'aria-label="Difficulty 3. View details for I will win exactly two 9s"',
+    );
+    expect(markup).not.toContain('data-slot="task-info"');
   });
 });

--- a/src/components/game/RoomShell.tsx
+++ b/src/components/game/RoomShell.tsx
@@ -113,6 +113,9 @@ const qualifierCopy: Record<CommunicationQualifier, string> = {
 const cardsById = new Map(CARD_DECK.map((card) => [card.id, card]));
 const playDropId = "crew:play-card";
 const communicationDropId = "crew:communicate-card";
+const taskClaimDragId = (taskId: string) => `crew:claim-task:${taskId}`;
+const taskClaimDropId = (playerId: string) =>
+  `crew:claim-task-player:${playerId}`;
 const reconnectingMessage =
   "Connection interrupted. Showing the latest confirmed state while we retry.";
 
@@ -198,6 +201,7 @@ export function RoomShell({
     cardId: CardId | null;
   }>(() => ({ scope: handScope, mode: false, cardId: null }));
   const [draggedCardId, setDraggedCardId] = useState<CardId | null>(null);
+  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
   const [interactionAnnouncement, setInteractionAnnouncement] = useState("");
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -214,6 +218,8 @@ export function RoomShell({
       ? communicationState.cardId
       : null;
   const draggedCard = projectedCard(draggedCardId);
+  const draggedTask =
+    projection.tasks.find((task) => task.id === draggedTaskId) ?? null;
   const won = projection.phase === "finished" && projection.result === "won";
   const connectionToastId = `room-connection:${projection.room.id}`;
   const messageToastId = `room-message:${projection.room.id}`;
@@ -247,11 +253,33 @@ export function RoomShell({
   }, [connectionToastId, messageToastId]);
 
   function handleDragStart({ active }: DragStartEvent) {
+    if (active.data.current?.type === "claim-task") {
+      const taskId = active.data.current.taskId;
+      const task = projection.tasks.find(
+        (candidate) => candidate.id === taskId,
+      );
+      if (
+        !task ||
+        !projection.legalActions.claimableTaskIds.includes(task.id)
+      ) {
+        return;
+      }
+
+      setDraggedCardId(null);
+      setDraggedTaskId(task.id);
+      setInteractionAnnouncement(
+        `Dragging ${task.title}. Drop it on your Crew station to assign it to yourself.`,
+      );
+      return;
+    }
+
+    if (active.data.current?.type !== "hand-card") return;
     const card = projection.self.hand.find(
-      (candidate) => candidate.id === active.id,
+      (candidate) => candidate.id === active.data.current?.cardId,
     );
     if (!card) return;
 
+    setDraggedTaskId(null);
     setDraggedCardId(card.id);
     setInteractionAnnouncement(
       `Dragging ${cardName(card)}. Drop it on your played or communication station.`,
@@ -259,8 +287,40 @@ export function RoomShell({
   }
 
   function handleDragEnd({ active, over }: DragEndEvent) {
+    if (active.data.current?.type === "claim-task") {
+      const taskId = active.data.current.taskId;
+      const task = projection.tasks.find(
+        (candidate) => candidate.id === taskId,
+      );
+      setDraggedTaskId(null);
+
+      if (
+        !task ||
+        !over ||
+        actionPending ||
+        over.id !== taskClaimDropId(projection.self.id) ||
+        !projection.legalActions.claimableTaskIds.includes(task.id)
+      ) {
+        setInteractionAnnouncement(
+          task ? `${task.title} returned to the mission board.` : "Task drag cancelled.",
+        );
+        return;
+      }
+
+      setInteractionAnnouncement(`Assigning ${task.title} to you.`);
+      void sendCommand({ type: "claim-task", taskId: task.id }).then((sent) => {
+        setInteractionAnnouncement(
+          sent
+            ? `${task.title} assigned to you.`
+            : `${task.title} could not be assigned.`,
+        );
+      });
+      return;
+    }
+
+    if (active.data.current?.type !== "hand-card") return;
     const card = projection.self.hand.find(
-      (candidate) => candidate.id === active.id,
+      (candidate) => candidate.id === active.data.current?.cardId,
     );
     setDraggedCardId(null);
 
@@ -305,6 +365,12 @@ export function RoomShell({
   }
 
   function handleDragCancel() {
+    if (draggedTask) {
+      setDraggedTaskId(null);
+      setInteractionAnnouncement(`Stopped dragging ${draggedTask.title}.`);
+      return;
+    }
+
     const card = projectedCard(draggedCardId);
     setDraggedCardId(null);
     setInteractionAnnouncement(
@@ -333,6 +399,7 @@ export function RoomShell({
             projection={projection}
             pending={actionPending}
             draggedCard={draggedCard}
+            draggedTask={draggedTask}
             sendCommand={sendCommand}
             onForget={onForget}
           />
@@ -356,8 +423,23 @@ export function RoomShell({
         }
       />
       <DragOverlay dropAnimation={null}>
-        {draggedCard ? (
-          <div aria-hidden="true" className="rotate-2 opacity-95 shadow-xl">
+        {draggedTask ? (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none rotate-2 opacity-95 shadow-xl"
+          >
+            <TaskTile
+              emphasized
+              showBoot={false}
+              task={draggedTask}
+              card={projectedCard(draggedTask.cardId)}
+            />
+          </div>
+        ) : draggedCard ? (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none rotate-2 opacity-95 shadow-xl"
+          >
             <GameCard card={draggedCard} />
           </div>
         ) : null}
@@ -370,12 +452,14 @@ function RoomConsole({
   projection,
   pending,
   draggedCard,
+  draggedTask,
   sendCommand,
   onForget,
 }: {
   projection: ActorProjection;
   pending: boolean;
   draggedCard: Card | null;
+  draggedTask: ActorProjection["tasks"][number] | null;
   sendCommand: RoomShellProps["sendCommand"];
   onForget: () => void;
 }) {
@@ -393,6 +477,7 @@ function RoomConsole({
             layout="main"
             pending={pending}
             draggedCard={draggedCard}
+            draggedTask={draggedTask}
             sendCommand={sendCommand}
           />
         ) : (
@@ -418,6 +503,7 @@ function RoomConsole({
           }
           pending={pending}
           draggedCard={draggedCard}
+          draggedTask={draggedTask}
           sendCommand={sendCommand}
         />
       )}
@@ -513,9 +599,7 @@ function TaskBoard({
   sendCommand: (command: PlayerCommand) => Promise<boolean>;
 }) {
   const isAssigning = projection.phase === "assigning-tasks";
-  const showTaskInfo =
-    projection.mission.editionKey === "deep-sea" &&
-    (isAssigning || projection.phase === "ready-to-start-trick");
+  const showTaskInfo = projection.mission.editionKey === "deep-sea";
   const visibleTasks = isAssigning
     ? projection.tasks.filter((task) => task.ownerPlayerId === null)
     : projection.tasks;
@@ -545,8 +629,13 @@ function TaskBoard({
           const releasable = projection.legalActions.releasableTaskIds.includes(task.id);
           const canResolve = projection.legalActions.taskOutcomeTaskIds.includes(task.id);
           const selectionBoot =
-            showTaskInfo && (claimable || releasable) ? (
-              <TaskBoot emphasized={isAssigning} showInfo task={task} />
+            claimable || releasable ? (
+              <TaskBoot
+                card={projectedCard(task.cardId)}
+                emphasized={isAssigning}
+                showInfo={showTaskInfo}
+                task={task}
+              />
             ) : undefined;
           const tile = (
             <TaskTile
@@ -621,29 +710,61 @@ function TaskBoard({
   );
 }
 
-function TaskSelectionButton({
-  action,
-  task,
-  pending,
-  sendCommand,
-  children,
-  boot,
-}: {
+type TaskSelectionButtonProps = {
   action: "claim" | "release";
   task: ActorProjection["tasks"][number];
   pending: boolean;
   sendCommand: (command: PlayerCommand) => Promise<boolean>;
   children: ReactNode;
   boot?: ReactNode;
-}) {
+};
+
+type TaskSelectionDragProps = Pick<
+  ReturnType<typeof useDraggable>,
+  "isDragging" | "listeners" | "setNodeRef"
+>;
+
+function TaskSelectionButton(props: TaskSelectionButtonProps) {
+  return props.action === "claim" ? (
+    <DraggableTaskClaimButton {...props} />
+  ) : (
+    <TaskSelectionControl {...props} />
+  );
+}
+
+function DraggableTaskClaimButton(props: TaskSelectionButtonProps) {
+  const drag = useDraggable({
+    id: taskClaimDragId(props.task.id),
+    disabled: props.pending,
+    data: { type: "claim-task", taskId: props.task.id },
+  });
+
+  return <TaskSelectionControl {...props} drag={drag} />;
+}
+
+function TaskSelectionControl({
+  action,
+  task,
+  pending,
+  sendCommand,
+  children,
+  boot,
+  drag,
+}: TaskSelectionButtonProps & { drag?: TaskSelectionDragProps }) {
   const isClaim = action === "claim";
 
   const selectionButton = (
     <button
+      {...drag?.listeners}
       className={cn(
         "cursor-pointer rounded-md border-0 bg-transparent p-0 text-inherit focus-visible:outline-[3px] focus-visible:outline-solid focus-visible:outline-task-focus focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60",
         boot && "*:data-task-outcome:pb-0",
+        isClaim && "cursor-grab touch-pan-y active:cursor-grabbing",
+        drag?.isDragging && "opacity-30",
       )}
+      data-task-dragging={drag ? (drag.isDragging ? "true" : "false") : undefined}
+      data-task-id={task.id}
+      ref={drag?.setNodeRef}
       type="button"
       disabled={pending}
       aria-label={isClaim ? `Assign ${task.title} to me` : `Deselect ${task.title}`}
@@ -975,20 +1096,82 @@ function MissionOutcomeActions({
   );
 }
 
+function TaskDroppableCrewStation({
+  taskDropId: dropId,
+  taskDropEnabled,
+  taskDropTarget,
+  taskDragging,
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"article"> & {
+  taskDropId: string;
+  taskDropEnabled: boolean;
+  taskDropTarget: boolean;
+  taskDragging: boolean;
+}) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: dropId,
+    disabled: !taskDropEnabled,
+    data: { type: "claim-task-target" },
+  });
+  const dropState = taskDragging && taskDropTarget
+    ? taskDropEnabled
+      ? isOver
+        ? "active"
+        : "available"
+      : "unavailable"
+    : "idle";
+
+  return (
+    <article
+      {...props}
+      className={cn(
+        "relative transition-[background-color,box-shadow] motion-reduce:transition-none",
+        dropState === "available" &&
+          "bg-indigo-50/80 ring-2 ring-inset ring-indigo-300",
+        dropState === "active" &&
+          "bg-indigo-100 ring-4 ring-inset ring-indigo-600",
+        className,
+      )}
+      data-task-drop-state={taskDropTarget ? dropState : undefined}
+      data-task-drop-target={taskDropTarget ? "claim" : undefined}
+      ref={setNodeRef}
+    >
+      {children}
+      {taskDragging && taskDropTarget && taskDropEnabled ? (
+        <span
+          className={cn(
+            "pointer-events-none absolute inset-0 z-30 grid place-items-center rounded-xl border-2 border-dashed border-indigo-500 bg-white/90 px-2 text-center text-xs leading-tight font-bold text-indigo-700 uppercase backdrop-blur-sm",
+            dropState === "active" &&
+              "border-solid bg-indigo-100/95 text-indigo-900",
+          )}
+          aria-hidden="true"
+        >
+          Assign to me
+        </span>
+      ) : null}
+    </article>
+  );
+}
+
 function CrewPanels({
   projection,
   layout,
   pending,
   draggedCard,
+  draggedTask,
   sendCommand,
 }: {
   projection: ActorProjection;
   layout: "compact" | "main" | "strip";
   pending: boolean;
   draggedCard: Card | null;
+  draggedTask: ActorProjection["tasks"][number] | null;
   sendCommand: (command: PlayerCommand) => Promise<boolean>;
 }) {
   const visibleTrick = projection.currentTrick ?? projection.lastTrick;
+  const showTaskInfo = projection.mission.editionKey === "deep-sea";
 
   return (
     <section
@@ -1027,15 +1210,25 @@ function CrewPanels({
               (option) => option.cardId === draggedCard.id,
             ),
         );
+        const canDropTask = Boolean(
+          isSelf &&
+            draggedTask &&
+            !pending &&
+            projection.legalActions.claimableTaskIds.includes(draggedTask.id),
+        );
 
         return (
-          <article
+          <TaskDroppableCrewStation
             className={cn(
               "min-h-0 min-w-0 border-l-2 border-solid border-l-gray-200 px-4 pt-1 pb-2 first:border-l-0 min-[701px]:max-[1100px]:px-2 max-[700px]:snap-center max-[700px]:overflow-y-auto",
               layout === "main" ? "overflow-y-auto" : "overflow-hidden",
             )}
             key={player.id}
             aria-label={`${player.displayName} station`}
+            taskDropEnabled={canDropTask}
+            taskDropId={taskClaimDropId(player.id)}
+            taskDropTarget={isSelf}
+            taskDragging={Boolean(draggedTask)}
           >
             <header className="flex min-h-12 items-center justify-center gap-[0.45rem] min-[701px]:[@media(max-height:720px)]:min-h-10">
               <span
@@ -1109,11 +1302,20 @@ function CrewPanels({
                     projection.legalActions.taskOutcomeTaskIds.includes(task.id);
                   const releasable =
                     projection.legalActions.releasableTaskIds.includes(task.id);
+                  const selectionBoot = releasable ? (
+                    <TaskBoot
+                      card={projectedCard(task.cardId)}
+                      showInfo={showTaskInfo}
+                      task={task}
+                    />
+                  ) : undefined;
                   const tile = (
                     <TaskTile
                       task={task}
                       card={projectedCard(task.cardId)}
                       ownerName={player.displayName}
+                      showBoot={!selectionBoot}
+                      showInfo={showTaskInfo}
                       action={
                         canResolve ? (
                           <TaskOutcomeActions
@@ -1133,6 +1335,7 @@ function CrewPanels({
                       pending={pending}
                       sendCommand={sendCommand}
                       task={task}
+                      boot={selectionBoot}
                     >
                       {tile}
                     </TaskSelectionButton>
@@ -1142,7 +1345,7 @@ function CrewPanels({
                 })}
               </div>
             ) : null}
-          </article>
+          </TaskDroppableCrewStation>
         );
       })}
     </section>
@@ -1266,7 +1469,7 @@ function RoomDock({
 }) {
   const dockRef = useRef<HTMLElement>(null);
   const firstQualifierRef = useRef<HTMLButtonElement>(null);
-  const selectedCardRef = useRef<HTMLButtonElement>(null);
+  const communicatingCardRef = useRef<HTMLButtonElement>(null);
   const canCommunicate =
     projection.legalActions.communicationOptions.length > 0;
   const isCommunicationMode = communicationMode && canCommunicate;
@@ -1282,7 +1485,7 @@ function RoomDock({
   }, [communicatingCardId]);
 
   function closeCommunicationPicker() {
-    selectedCardRef.current?.focus();
+    communicatingCardRef.current?.focus();
     onCommunicationChange(isCommunicationMode, null);
   }
 
@@ -1327,7 +1530,7 @@ function RoomDock({
                 projection.legalActions.communicationOptions.some(
                   (option) => option.cardId === card.id,
                 );
-              const interactive = isCommunicationMode
+              const canActivate = isCommunicationMode
                 ? communicable
                 : playable;
 
@@ -1336,10 +1539,9 @@ function RoomDock({
                   card={card}
                   disabled={pending}
                   key={card.id}
-                  selected={communicatingCardId === card.id}
                   buttonRef={
                     communicatingCardId === card.id
-                      ? selectedCardRef
+                      ? communicatingCardRef
                       : undefined
                   }
                   labelPrefix={
@@ -1352,7 +1554,7 @@ function RoomDock({
                         : "Unavailable"
                   }
                   onClick={
-                    interactive
+                    canActivate
                       ? isCommunicationMode
                         ? () => onCommunicationChange(true, card.id)
                         : () =>
@@ -1425,14 +1627,12 @@ function RoomDock({
 function DraggableHandCard({
   card,
   disabled,
-  selected,
   buttonRef,
   labelPrefix,
   onClick,
 }: {
   card: Card;
   disabled: boolean;
-  selected: boolean;
   buttonRef?: Ref<HTMLButtonElement>;
   labelPrefix: string;
   onClick?: () => void;
@@ -1440,7 +1640,7 @@ function DraggableHandCard({
   const { isDragging, listeners, setNodeRef } = useDraggable({
     id: card.id,
     disabled,
-    data: { type: "hand-card" },
+    data: { type: "hand-card", cardId: card.id },
   });
 
   return (
@@ -1463,7 +1663,6 @@ function DraggableHandCard({
         <GameCard
           card={card}
           disabled={disabled}
-          selected={selected}
           buttonRef={buttonRef}
           labelPrefix={labelPrefix}
           onClick={onClick}

--- a/src/components/game/TaskBoot.tsx
+++ b/src/components/game/TaskBoot.tsx
@@ -1,4 +1,4 @@
-import { BadgeInfo, Check, Gauge, Radio, X } from "lucide-react";
+import { Check, Gauge, Radio, X } from "lucide-react";
 
 import {
   Dialog,
@@ -26,18 +26,10 @@ const orderCopy: Record<NonNullable<ProjectedTask["order"]>, string> = {
   "last-trick": "Ω",
 };
 
-const statusIconClassName: Record<TaskOutcome, string> = {
-  pending: "text-blue-400",
-  success: "text-green-500",
-  failure: "text-red-600",
-};
-
-const orderSuitClassName: Record<Card["suit"], string> = {
-  pink: "border-card-pink",
-  blue: "border-card-blue",
-  green: "border-card-green",
-  yellow: "border-card-yellow",
-  trump: "border-card-trump",
+const statusClassName: Record<TaskOutcome, string> = {
+  pending: "bg-white text-black",
+  success: "bg-green-500 text-white",
+  failure: "bg-red-600 text-white",
 };
 
 export type TaskBootProps = {
@@ -60,60 +52,37 @@ export function TaskBoot({
   const deepSeaDefinition = resolvedCard
     ? null
     : findDeepSeaTask(task.definitionId);
-  const order =
-    resolvedCard && task.order
-      ? { copy: orderCopy[task.order], suit: resolvedCard.suit }
-      : null;
+  const order = resolvedCard && task.order ? orderCopy[task.order] : null;
 
   const boot = (
     <div
-      className="flex h-5 w-14 items-center justify-between rounded-b-md bg-slate-200 px-1 text-task-ink"
+      className="grid h-5 w-14 grid-cols-2 items-center rounded-b-md bg-slate-200 px-1 text-task-ink"
       data-slot="task-boot"
     >
-      <span
-        className={cn(
-          "grid size-3.5 shrink-0 place-items-center rounded-full bg-white",
-          statusIconClassName[task.outcome],
-        )}
-        data-slot="task-status"
-        aria-hidden="true"
-      >
-        <TaskStatusIcon outcome={task.outcome} />
-      </span>
-
       {order ? (
         <span
-          className={cn(
-            "inline-flex size-3.5 shrink-0 items-center justify-center rounded-full border bg-white text-[0.55rem] leading-none text-task-ink forced-colors:border-[CanvasText]",
-            orderSuitClassName[order.suit],
-          )}
+          className="col-start-1 row-start-1 inline-flex size-3.5 shrink-0 items-center justify-center justify-self-start rounded-full bg-white text-[0.55rem] leading-none text-task-ink"
           data-slot="task-order"
           aria-hidden="true"
         >
-          {order.copy}
+          {order}
         </span>
       ) : null}
 
-      {deepSeaDefinition && task.difficulty !== null ? (
-        <span
-          className="inline-flex size-3.5 shrink-0 items-center justify-center gap-px rounded-full bg-white text-[0.45rem] leading-none"
-          data-slot="deep-sea-task-difficulty"
-          aria-label={`Difficulty ${task.difficulty}`}
-        >
-          <Gauge className="size-2" aria-hidden="true" />
-          <span aria-hidden="true">{task.difficulty}</span>
-        </span>
-      ) : null}
-
-      {showInfo && deepSeaDefinition ? (
+      {showInfo && deepSeaDefinition && task.difficulty !== null ? (
         <Dialog>
           <DialogTrigger asChild>
             <button
-              className="relative grid size-3.5 shrink-0 cursor-pointer place-items-center rounded-full border-0 bg-white p-0 text-task-ink transition-colors before:absolute before:-inset-1 before:rounded-full hover:bg-slate-100 hover:text-indigo-700 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-indigo-700"
+              className="group relative col-start-1 row-start-1 inline-flex h-3.5 shrink-0 cursor-pointer items-center justify-center justify-self-start gap-px rounded-full border-0 bg-white px-0.5 py-0 text-[0.55rem] leading-none text-task-ink before:absolute before:-inset-1 before:rounded-full focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-indigo-700"
+              data-slot="deep-sea-task-difficulty"
               type="button"
-              aria-label={`View details for ${task.title}`}
+              aria-label={`Difficulty ${task.difficulty}. View details for ${task.title}`}
             >
-              <BadgeInfo className="size-3" aria-hidden="true" />
+              <Gauge
+                className="size-2.5 transition-colors group-hover:text-slate-600"
+                aria-hidden="true"
+              />
+              <span aria-hidden="true">{task.difficulty}</span>
             </button>
           </DialogTrigger>
           <DialogContent>
@@ -133,16 +102,38 @@ export function TaskBoot({
             ) : null}
           </DialogContent>
         </Dialog>
+      ) : deepSeaDefinition && task.difficulty !== null ? (
+        <span
+          className="col-start-1 row-start-1 inline-flex h-3.5 shrink-0 items-center justify-center justify-self-start gap-px rounded-full bg-white px-0.5 text-[0.55rem] leading-none"
+          data-slot="deep-sea-task-difficulty"
+          aria-label={`Difficulty ${task.difficulty}`}
+        >
+          <Gauge className="size-2.5" aria-hidden="true" />
+          <span aria-hidden="true">{task.difficulty}</span>
+        </span>
       ) : null}
+
+      <span
+        className={cn(
+          "col-start-2 row-start-1 grid size-3.5 shrink-0 place-items-center justify-self-end rounded-full",
+          statusClassName[task.outcome],
+        )}
+        data-slot="task-status"
+        aria-hidden="true"
+      >
+        <TaskStatusIcon outcome={task.outcome} />
+      </span>
     </div>
   );
 
   return (
     <div
       className={cn(
+        "relative before:absolute before:inset-x-0 before:-top-1 before:z-0 before:h-1 before:bg-slate-200 before:content-['']",
         emphasized ? "h-7.5 w-21" : "h-5 w-14",
         className,
       )}
+      data-slot="task-boot-frame"
     >
       <div className={emphasized ? "origin-top-left scale-150" : undefined}>
         {boot}

--- a/src/components/game/TaskTile.test.tsx
+++ b/src/components/game/TaskTile.test.tsx
@@ -1,6 +1,8 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { DEEP_SEA_TASK_VISUALS } from "@/game/config/deep-sea-task-visuals";
+
 import type { Card, ProjectedTask } from "./types";
 import { TaskTile } from "./TaskTile";
 
@@ -34,7 +36,7 @@ function taskFor(
 }
 
 describe("TaskTile", () => {
-  it("puts Deep Sea status, difficulty, and optional info in TaskBoot", () => {
+  it("uses the Deep Sea difficulty as the optional TaskBoot info trigger", () => {
     const markup = renderToStaticMarkup(
       <TaskTile
         emphasized
@@ -51,9 +53,25 @@ describe("TaskTile", () => {
     expect(markup).toContain('data-slot="task-status"');
     expect(markup).toContain('data-slot="deep-sea-task-difficulty"');
     expect(markup).toContain("lucide-gauge");
-    expect(markup).toContain("lucide-badge-info");
+    expect(markup).toContain("h-3.5");
+    expect(markup).toContain("px-0.5");
+    expect(markup).not.toContain("w-7");
+    expect(markup).toContain("size-2.5");
+    expect(markup).not.toContain("lucide-badge-info");
+    expect(markup).not.toContain('data-slot="task-info"');
+    expect(markup).toContain(
+      'aria-label="Difficulty 3. View details for I will win exactly two 9s"',
+    );
     expect(markup).toContain("View details for I will win exactly two 9s");
     expect(markup).not.toContain('data-slot="task-order"');
+    expect(
+      markup.match(
+        /data-slot="(?:deep-sea-task-difficulty|task-info|task-status)"/g,
+      ),
+    ).toEqual([
+      'data-slot="deep-sea-task-difficulty"',
+      'data-slot="task-status"',
+    ]);
   });
 
   it("shows Deep Sea difficulty without requiring the info button", () => {
@@ -129,12 +147,39 @@ describe("TaskTile", () => {
     expect(header).toContain("WIN MORE");
     expect(header.match(/WIN MORE/g)).toHaveLength(1);
     expect(wildcard).toContain('data-card-suit="wild"');
-    expect(wildcard).toContain("data:image/png;base64,");
+    expect(wildcard).toMatch(
+      /class="[^"]*text-white[^"]*"[^>]*data-card-suit="wild"/,
+    );
+    expect(wildcard).toContain("background-image:conic-gradient(");
+    expect(wildcard).toContain("var(--color-red-400)");
+    expect(wildcard).toContain("var(--color-amber-400)");
+    expect(wildcard).toContain("var(--color-emerald-500)");
+    expect(wildcard).toContain("var(--color-sky-500)");
+    expect(wildcard).not.toContain("data:image/");
     expect(text).toContain('data-slot="deep-sea-task-text"');
     expect(text).toContain("Win =X tricks (public)");
     expect(cardsFace).toContain('data-slot="deep-sea-task-cards"');
     expect(
       cardsFace.match(/data-slot="deep-sea-task-mini-card"/g),
     ).toHaveLength(4);
+  });
+
+  it("uses centered multiplication signs for zero-count Deep Sea visuals", () => {
+    const visuals = JSON.stringify(DEEP_SEA_TASK_VISUALS);
+    const header = renderToStaticMarkup(
+      <TaskTile task={taskFor(null, { definitionId: "deep-sea-task-6" })} />,
+    );
+    const cardsFace = renderToStaticMarkup(
+      <TaskTile task={taskFor(null, { definitionId: "deep-sea-task-26" })} />,
+    );
+    const text = renderToStaticMarkup(
+      <TaskTile task={taskFor(null, { definitionId: "deep-sea-task-51" })} />,
+    );
+
+    expect(visuals).toContain("0×");
+    expect(visuals).not.toMatch(/0(?:x|ˣ)/);
+    expect(header).toContain("WIN =0×");
+    expect(cardsFace.match(/0×/g)).toHaveLength(2);
+    expect(text).toContain("Win 0× tricks");
   });
 });

--- a/src/components/game/TaskTile.tsx
+++ b/src/components/game/TaskTile.tsx
@@ -15,8 +15,8 @@ import {
 import { TaskBoot } from "./TaskBoot";
 import type { Card, ProjectedTask, TaskOutcome } from "./types";
 
-const LEGACY_RAINBOW_BACKGROUND_IMAGE =
-  'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAb1SURBVHgB7Z1baFxFGID/s7tptrlsSpEkGIwPNe0WRH0w8aE+NVUffGhS+1SSIL61iSCISJ9EEH0oEURFpaAkFaEqVRDRaougtYFWaHNpKmlqNUmbi63NpindbZNd5z+bLaFN2plzZubMmf0/WLahsxD48l9mzsysM7qxIQdFxItt/VBMRICwGhJsOSTYckiw5ZBgyyHBlkOCLYcEWw4JtpwYWIKTSEC8sRFiD9ZBhL1idfmXU1kJ0cqE+44cWRp/PZOD+TTAVCr/8+h0FqbncnB+Gl8A8xk7FvicsC5Vosi1zc1QsikJa5qa3J9lMp3KwegMwO8ji3B+Ji8+jIRKcGljE8S3NrtiZQu9Hyj89FgWfhrMQv9YeGQbLxhTb2VbO6xlYkuSm8EEUHbPsUUYYKKnUmbLNlZwSTIJZdtboaKl9Xb9NJHDg4tw4FjWWNHGCY6yxmj9W2+76ThMmCraGMGYiqt2d0JFeweEGdNEGyG4sq0DEp1dRqdiEQo1GhuyoAlUcFjTMS/Ybe/7fiHQaA5MsG1RuxrzGYBeFs2HTi5CEGhfybKl1vJSUQqwpzkKNQmAj47ql6w1gjElP/DeB+4UqBjB2vzqF3pTtraHDSi3+tOeopWL1FQ50L0rBrXsXRdaBKPU2q+/cSUXOyj545dKYEONHsnKBaPc6s96rW+mRMC63L1Lj2Slgknu6uiSrEywW3NJ7j0pSFZZk5UILjRUJPf+5CWra7yUCEa51FDxg43XmztirmzZSBe87vW9JNcDWIvbn46CbKQKxuXHYlmhUsELjVHY0ShXsjTBGLW4tkz4o4NFscx6LE0wPhWipso/WIdfe17eIwIpgstbWqx95BcEj9c70lK1b8Fuat5NqVk2mKpldNW+BSf2dFLXrACUK6Or9iUYxZZvbwVCDdhV+224fAnG6CXU4rfh8iyYolcP2HD5eSDhWTBFrz6ee9R7ovX0SYpevTz7mPeO2pNgPKZJ6APlep0XexJM8179bGnwlqaFP4UrVjTv1Q82WthwiSIsuIwtSxLB4CWKhT8Rf5LWnINiy0bFgnETHaXn4MCdHzWCK1tCgtcU8aZ1UxCNYqHR8a3bgAiWDdUqI3gTRXDQPFGvSHAE75ui+hs4WINFVrW4BZtyww0BQvNhbsGUns2hZh1/ZeUeSenZHGoT/GMFUjRFsCkoiWDCHJREMKVoc6iI84/lF1wp8GdDKKU8rqCLplML5qBkHkyEk9jDn/Bd6RPMNV7Eagw/tY9rHEWw5fALXrgGhBnMLaS5x/ILXpwDwgxSCxnusQIRTIJNYSI9yz2Wf5qUvgRE+OCP4MwEEGYwND/NPZZfcPoiEGYwcUNFir5JKdoUzszPcI/lF5w6AYQZqEnR2EVnKE0HzXg6pWgezHBmKYqDZvjalNB4saXK62eBCJYfLo8IjRcSHPnvKBDBMjyvMoKxBlMdDgysv0MCHTQi/DTJuXIEiGA4fvUfEEVcMKXpwPhqagBEERfM5sMONVvawfR8fFZDBLtcoSjWTfeFX8ELngRHJntpA4Bm+jxEL+ItgtmqljNzCAg9HJwccFO0FzzvyYrMfAuEHt7921t6RrxvumONFj2AUI+f6EV87aqMnNsLhFr8RC/ib9ssW9VyJnuAUIPf6EV874uOjH1IHbUCUKzf6EX8b3xnHXVk/H0g5ILzXr/Ri0g52eBc6qWGSyJ9bM35Sw/Lkish7eiK23BRqvbN3EIGXvnzO5CFvLNJrOGiVO0fWam5gNTDZ26qpq7aM/snTrgvmUg/XYhdNT1tEgej9o1zP4Ns5B8fxa76bBc4tPODG5S789QBUIGa88FYjwc7qOniAJsqlCuz7i5H3QFwlDxEku+FarmI0hP+WItJ8soU5IqcUvCC8iscSPLd6JKLaLmjAyVHT7dQ4wX5huqZk/u1yEX0XcKy1HgVs2SUqrrm3oneW3ZQ8h/NRbkYggsYO099rlUuIu/L4gWI/PUO5NIXIfvQy+w3sPsGPay3uPwoe4WKF+fWL4/w3YSmgtI6yDYw2VV2fhcTPhXCBwe6o3Y5wQpeIlfdCrn6LsiV2nGjbdBRuxwjBLtgNKPk6nB/bS1K7b7wm9AhbZWYI7hASEWbkI5XwjzBBUIgGlPxwcl+91CYrnmtKOYKLsBEYxNmUo0+w2T++O+Im45NScWrYb7gZbiiMaLxXbPs8fSsK/Xw5RFPp/yCIlSCl5Mr3wxQnoTc+m0AFUnpwlFo39WxfLQyqeMC90OaRGgF30UswaQnAcqY7DiTXb70TW347yj7vzsWVLB+phZuwNytDEywxmiMCcT3wjlc01MvL/YI5qTmZjsUE3Tju+WQYMshwZZDgi2HBFsOCbYcEmw5JNhySLDl/A95A59TRbyxJQAAAABJRU5ErkJggg==")';
+const ANY_COLOR_BACKGROUND_IMAGE =
+  "conic-gradient(var(--color-red-400), var(--color-amber-400), var(--color-emerald-500), var(--color-sky-500), var(--color-red-400))";
 
 const statusLabel: Record<TaskOutcome, string> = {
   pending: "Pending",
@@ -69,14 +69,14 @@ export function TaskTile({
   return (
     <div
       className={cn(
-        "inline-grid w-max justify-items-center gap-0 p-[0.45rem]",
+        "relative isolate inline-grid w-max justify-items-center gap-0 p-[0.45rem]",
         className,
       )}
       data-task-outcome={task.outcome}
     >
       <div
         className={cn(
-          "relative grid place-items-center text-task-ink",
+          "relative z-1 grid place-items-center text-task-ink",
           emphasized ? "size-21" : "size-14",
         )}
         data-slot="task-tile"
@@ -245,12 +245,12 @@ function TaskMiniPill({ item }: { item: DeepSeaTaskVisualItem }) {
         "grid size-5 place-items-center rounded-full bg-cover font-display leading-none",
         item.suit
           ? [CARD_SUIT_COLOR_CLASS_NAME[item.suit], "bg-current"]
-          : "text-black",
+          : "text-white",
       )}
       style={
         item.suit
           ? undefined
-          : { backgroundImage: LEGACY_RAINBOW_BACKGROUND_IMAGE }
+          : { backgroundImage: ANY_COLOR_BACKGROUND_IMAGE }
       }
       data-card-suit={item.suit ?? "wild"}
       data-slot="deep-sea-task-mini-card"

--- a/src/game/config/deep-sea-task-visuals.ts
+++ b/src/game/config/deep-sea-task-visuals.ts
@@ -27,7 +27,7 @@ export const DEEP_SEA_TASK_VISUALS = [
   },
   { kind: "text", text: "Win =X tricks (public)" },
   { kind: "header", header: "WIN USING", items: [{ value: 2 }] },
-  { kind: "header", header: "WIN =0x", items: [{ value: 5 }] },
+  { kind: "header", header: "WIN =0×", items: [{ value: 5 }] },
   { kind: "header", header: "WIN >1x", items: [{ value: 7 }] },
   { kind: "text", text: "Win first and second trick" },
   {
@@ -90,8 +90,8 @@ export const DEEP_SEA_TASK_VISUALS = [
   {
     kind: "cards",
     cards: [
-      { value: "0ˣ", suit: "yellow" },
-      { value: "0ˣ", suit: "green" },
+      { value: "0×", suit: "yellow" },
+      { value: "0×", suit: "green" },
     ],
   },
   { kind: "header", header: "WIN USING", items: [{ value: 6 }] },
@@ -106,7 +106,7 @@ export const DEEP_SEA_TASK_VISUALS = [
     text: "Win a trick with value >{23,28,31}\n(no Trump)",
   },
   { kind: "text", text: "Not win any of the first 5 tricks" },
-  { kind: "header", header: "WIN =0x", items: [{ suit: "pink" }] },
+  { kind: "header", header: "WIN =0×", items: [{ suit: "pink" }] },
   { kind: "header", header: "WIN =3x", items: [{ suit: "trump" }] },
   {
     kind: "cards",
@@ -142,12 +142,12 @@ export const DEEP_SEA_TASK_VISUALS = [
   },
   {
     kind: "header",
-    header: "WIN =0x",
+    header: "WIN =0×",
     items: [{ suit: "pink" }, { suit: "blue" }],
   },
   { kind: "cards", cards: [{ value: 3, suit: "pink" }] },
   { kind: "header", header: "WIN >2x", items: [{ value: 5 }] },
-  { kind: "header", header: "WIN =0x", items: [{ value: 1 }] },
+  { kind: "header", header: "WIN =0×", items: [{ value: 1 }] },
   { kind: "text", text: "Win a trick with value 22/33\n(no Trump)" },
   {
     kind: "cards",
@@ -156,7 +156,7 @@ export const DEEP_SEA_TASK_VISUALS = [
       { value: 5, suit: "blue" },
     ],
   },
-  { kind: "text", text: "Win 0x tricks" },
+  { kind: "text", text: "Win 0× tricks" },
   { kind: "text", text: "Win Trump 1 and no other Trump" },
   {
     kind: "header",
@@ -198,11 +198,11 @@ export const DEEP_SEA_TASK_VISUALS = [
   { kind: "text", text: "Not win any 1, 2, or 3" },
   {
     kind: "header",
-    header: "WIN =0x",
+    header: "WIN =0×",
     items: [{ value: 8 }, { value: 9 }],
   },
   { kind: "text", text: "Win only the first trick" },
-  { kind: "header", header: "WIN =0x", items: [{ suit: "green" }] },
+  { kind: "header", header: "WIN =0×", items: [{ suit: "green" }] },
   { kind: "cards", cards: [{ value: 1, suit: "yellow" }] },
   {
     kind: "cards",
@@ -219,13 +219,13 @@ export const DEEP_SEA_TASK_VISUALS = [
     items: [{ value: 5 }, { text: "w" }, { value: 7 }],
   },
   { kind: "text", text: "Win as many tricks as the commander" },
-  { kind: "header", header: "WIN =0x", items: [{ suit: "yellow" }] },
+  { kind: "header", header: "WIN =0×", items: [{ suit: "yellow" }] },
   {
     kind: "text",
     text: "Win equal #Green and #Yellow in 1 trick (>0)",
   },
   { kind: "text", text: "Win the last trick" },
-  { kind: "header", header: "WIN =0x", items: [{ value: 9 }] },
+  { kind: "header", header: "WIN =0×", items: [{ value: 9 }] },
   { kind: "cards", cards: [{ value: 6, suit: "green" }] },
   { kind: "header", header: "WIN =2x", items: [{ value: 9 }] },
   {
@@ -238,7 +238,7 @@ export const DEEP_SEA_TASK_VISUALS = [
   { kind: "cards", cards: [{ value: 4, suit: "blue" }] },
   { kind: "header", header: "WIN =1x", items: [{ suit: "trump" }] },
   { kind: "text", text: "Not open with Yellow, Red, or Blue" },
-  { kind: "header", header: "WIN =0x", items: [{ suit: "trump" }] },
+  { kind: "header", header: "WIN =0×", items: [{ suit: "trump" }] },
   { kind: "text", text: "Win exactly 2 tricks" },
   { kind: "text", text: "Win all cards of 1+ color" },
   { kind: "text", text: "Win 1+ cards of all colors" },


### PR DESCRIPTION
## Summary

- simplify playing-card rendering and the asset-gallery card controls
- refine the shared Deep Sea and Planet X task boot with fixed metadata/status ordering, outcome colors, compact hover treatment, and preserved rounded-face geometry
- make Deep Sea difficulty the details trigger in assignment and trick phases
- add click, keyboard, mouse-drag, and long-press touch task assignment to the current player's Crew station while preserving server-authoritative claim/release behavior
- normalize Deep Sea zero-count multiplication glyphs and refresh the wildcard mini-card treatment
- expand focused unit, accessibility, geometry, palette, and drag-interaction coverage

## Why

The task footer had accumulated competing status, difficulty, and info treatments that produced oversized hover geometry and inconsistent phase behavior. Task claiming was also click-only even though the room already had a shared drag system. The card gallery retained obsolete static/selected controls that no longer reflected production card behavior.

## Impact

Players get a consistent two-item footer in both editions, an accessible Deep Sea details control, and direct task-face assignment by click or drag without any server or schema changes. Existing card play and communication drag behavior remains intact.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` - 84 passed, 13 skipped
- `npm run build`
- focused Playwright suites for assets, card/task geometry, room accessibility, mouse task drops, keyboard fallbacks, and long-press touch assignment
